### PR TITLE
Stop pegging the CPU at 100% usage

### DIFF
--- a/walmart_inventory_lookup.py
+++ b/walmart_inventory_lookup.py
@@ -53,7 +53,13 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
+    frequency = args.repeat
+
+    if frequency > 0 and frequency < MIN_QUERY_FREQUENCY:
+        frequency = MIN_QUERY_FREQUENCY
+
     repeat = True
+
     while repeat:
         run_inventory_lookup(args.stores, args.item_id, args.sku, args.upc)
         time.sleep(args.repeat*60)

--- a/walmart_inventory_lookup.py
+++ b/walmart_inventory_lookup.py
@@ -1,7 +1,6 @@
 import requests
 import json
 import argparse
-import threading
 import time
 import datetime
 
@@ -44,27 +43,20 @@ def run_inventory_lookup(stores_id, item_id, sku, upc):
 	r = client.post(URL, params = payload, headers = headers)
 	alert_stock(json.loads(r.text), item_id)
 
-def run_inventory_lookup_multiple_time(stores_id, item_id, sku, upc, frequency):
-	if frequency < MIN_QUERY_FREQUENCY:
-		frequency = MIN_QUERY_FREQUENCY
-	run_inventory_lookup(stores_id, item_id, sku, upc)
-	t = threading.Timer(frequency*60, run_inventory_lookup_multiple_time, [stores_id, item_id, sku, upc, frequency])
-	t.daemon=True
-	t.start()
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Checks Walmart stocks for a given product in several stores', fromfile_prefix_chars='@')
+    parser.add_argument('--upc', help='UPC number of item', required=True)
+    parser.add_argument('--sku', help='sku number of item', default='')
+    parser.add_argument('--item_id', help='ID number of item', default='')
+    parser.add_argument('--stores', help='space separated store ids from which to check stock. Ex: --stores 3007 3008', nargs='+', required=True)
+    parser.add_argument('--repeat', type=int, help='repeats the query every X minute. Ex: --repeat 15', default=0)
 
+    args = parser.parse_args()
 
-parser = argparse.ArgumentParser(description='Checks Walmart stocks for a given product in several stores', fromfile_prefix_chars='@')
-parser.add_argument('--upc', help='UPC number of item', required=True)
-parser.add_argument('--sku', help='sku number of item', default='')
-parser.add_argument('--item_id', help='ID number of item', default='')
-parser.add_argument('--stores', help='space separated store ids from which to check stock. Ex: --stores 3007 3008', nargs='+', required=True)
-parser.add_argument('--repeat', type=int, help='repeats the query every X minute. Ex: --repeat 15', default=0)
+    repeat = True
+    while repeat:
+        run_inventory_lookup(args.stores, args.item_id, args.sku, args.upc)
+        time.sleep(args.repeat*60)
+        if args.repeat == 0:
+            repeat = False
 
-args = parser.parse_args()
-
-if args.repeat == 0:
-	run_inventory_lookup(args.stores, args.item_id, args.sku, args.upc)
-else:
-	run_inventory_lookup_multiple_time(args.stores, args.item_id, args.sku, args.upc, args.repeat)
-	while True:
-		pass


### PR DESCRIPTION
The previous implementation was causing 100% CPU usage at all times, when you kept the script running with `--repeat`

This PR eliminates the thread, eliminates the `run_inventory_lookup_multiple_time` function, keeps the check in the main loop, and does a `sleep()` in between inventory checks. When the process is sleeping, it uses no CPU at all.

The program will always enter the `while` loop one time, but will exit out after the first inventory check if `args.repeat` is 0. This reduces the duplication of having two separate inventory checking methods.

(FYI, you used tabs, I use spaces. I didn't switch my editor to use tabs, so now both are there. You might want to clean that up before merging).